### PR TITLE
Настройка env через django-environ и обновление compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 POSTGRES_DB=musson_db
 POSTGRES_USER=musson_user
 POSTGRES_PASSWORD=musson_pass
-DJANGO_SECRET_KEY=changeme
+DJANGO_SECRET_KEY=please_change_me
 DJANGO_DEBUG=True
 
 # API и фронтенд
@@ -10,4 +10,5 @@ API_URL=http://backend:8000/api/v1
 MEDIA_URL=http://backend:8000/media/
 FRONTEND_URL=http://frontend:3000
 DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1,backend
+CORS_ALLOWED_ORIGINS=http://localhost:3000
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,9 @@ jobs:
       - name: Run backend linters
         working-directory: ./backend
         run: |
+          isort --check --profile=django .
           flake8 .
           black --check .
-          isort --check-only .
 
       - name: Run backend tests
         working-directory: ./backend
@@ -76,7 +76,7 @@ jobs:
 
       - name: Install frontend dependencies
         working-directory: ./frontend
-        run: npm ci # Используйте npm ci для более быстрого и надежного билда в CI
+        run: npm install --legacy-peer-deps
 
       - name: Run frontend linters
         working-directory: ./frontend

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v5.10.1
     hooks:
       - id: isort
-        args: ["--profile", "black"]
+        args: ["--profile", "django"]
         files: \.py$
   - repo: https://github.com/psf/black
     rev: 24.4.2

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -196,3 +196,9 @@
 - Обновлена переменная окружения и docker-compose.
 - Добавлена health-проверка и React Query Devtools.
 - SiteSettingsFactory в тестах, новая инструкция по сбросу volume.
+
+## 2025-07-20
+- Переход на django-environ для чтения настроек.
+- docker-compose теперь использует блоковый синтаксис и переменную API_URL в backend.
+- CI запускает isort с профилем Django и npm install с legacy-peer-deps.
+- Добавлен документ `docs/ONBOARDING.md` с инструкциями по окружению.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,15 @@ npm run dev
 
 SSR uses `DJANGO_API_URL_SSR`, client uses `NEXT_PUBLIC_API_BASE`.
 
+Основные переменные из `.env`:
+
+- `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD` — параметры БД
+- `DJANGO_SECRET_KEY` — секретный ключ Django
+- `DJANGO_DEBUG` — режим отладки
+- `API_URL` — базовый адрес API, используется фронтендом
+- `DJANGO_ALLOWED_HOSTS` — хосты для Django
+- `CORS_ALLOWED_ORIGINS` — разрешённые источники CORS
+
 ### Docker (рекомендуемый способ для разработки и продакшена)
 
 1.  **Скопируйте `.env.example` в `.env`** и при необходимости измените `POSTGRES_PASSWORD`.
@@ -157,7 +166,7 @@ docker-compose -f docker/docker-compose.yml exec backend python manage.py genera
 - Запуск линтеров вручную:
 
   - `flake8` и `black --check` в каталоге `backend`
-  - `isort --check` для проверки порядка импортов
+  - `isort --check --profile=django` для проверки порядка импортов
   - `npm run lint` в каталоге `frontend`
 
 - **Python:** black, isort, flake8 (настроены в pre-commit и CI).

--- a/STATE.md
+++ b/STATE.md
@@ -45,3 +45,4 @@
 - [x] Расширена поддержка SiteSettings: singleton модель, кеширование и интеграция с React Query ✅
 - [x] Обновлён роутинг: include("core.urls") вместо устаревшего backend.urls ✅
 - [x] Стабилизированы Docker-файлы и отображение заголовка из админки ✅
+- [x] Переход на django-environ и обновлён docker-compose ✅

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -10,29 +10,37 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 
-import os
 from pathlib import Path
 
-from dotenv import load_dotenv
+import environ
 
-load_dotenv(os.path.join(Path(__file__).resolve().parent.parent, ".env"))
-
-# Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
+
+env = environ.Env(
+    DJANGO_SECRET_KEY=(str, "insecure-key"),
+    DJANGO_DEBUG=(bool, False),
+    POSTGRES_DB=(str, "musson_db"),
+    POSTGRES_USER=(str, "musson_user"),
+    POSTGRES_PASSWORD=(str, "musson_pass"),
+    POSTGRES_HOST=(str, "localhost"),
+    POSTGRES_PORT=(str, "5432"),
+    DJANGO_ALLOWED_HOSTS=(list, ["localhost", "127.0.0.1", "backend"]),
+    CORS_ALLOWED_ORIGINS=(list, []),
+)
+
+env.read_env(BASE_DIR.parent / ".env")
 
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.getenv("DJANGO_SECRET_KEY", "insecure-key")
+SECRET_KEY = env("DJANGO_SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.getenv("DJANGO_DEBUG", "False") == "True"
+DEBUG = env.bool("DJANGO_DEBUG")
 
-ALLOWED_HOSTS = os.getenv("DJANGO_ALLOWED_HOSTS", "localhost,127.0.0.1,backend").split(
-    ","
-)
+ALLOWED_HOSTS = env.list("DJANGO_ALLOWED_HOSTS")
 
 
 # Application definition
@@ -98,11 +106,11 @@ WSGI_APPLICATION = "config.wsgi.application"
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
-        "NAME": os.getenv("POSTGRES_DB", "musson_db"),
-        "USER": os.getenv("POSTGRES_USER", "musson_user"),
-        "PASSWORD": os.getenv("POSTGRES_PASSWORD", "musson_pass"),
-        "HOST": os.getenv("POSTGRES_HOST", "localhost"),
-        "PORT": os.getenv("POSTGRES_PORT", "5432"),
+        "NAME": env("POSTGRES_DB"),
+        "USER": env("POSTGRES_USER"),
+        "PASSWORD": env("POSTGRES_PASSWORD"),
+        "HOST": env("POSTGRES_HOST"),
+        "PORT": env("POSTGRES_PORT"),
     }
 }
 
@@ -161,7 +169,7 @@ MEDIA_ROOT = BASE_DIR / "media"
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
-CORS_ALLOW_ALL_ORIGINS = True  # dev only, для prod ограничить
+CORS_ALLOWED_ORIGINS = env.list("CORS_ALLOWED_ORIGINS")
 
 AUTH_USER_MODEL = "users.CustomUser"
 
@@ -185,7 +193,7 @@ SPECTACULAR_SETTINGS = {
 APPEND_SLASH = False
 
 # URL фронтенд-приложения для редиректов (например, для коротких ссылок)
-FRONTEND_URL = os.getenv("FRONTEND_URL", "http://localhost:3000")
+FRONTEND_URL = env("FRONTEND_URL", default="http://localhost:3000")
 
 CKEDITOR_5_CONFIGS = {
     "default": {

--- a/backend/requirements.in
+++ b/backend/requirements.in
@@ -4,7 +4,7 @@ django-cors-headers
 psycopg2-binary
 pytest
 pytest-django
-python-dotenv
+django-environ
 requests
 faker
 djangorestframework-simplejwt

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -109,7 +109,7 @@ pytest-cov==6.2.1
     # via -r backend/requirements.in
 pytest-django==4.11.1
     # via -r backend/requirements.in
-python-dotenv==1.1.0
+django-environ==0.12.0
     # via -r backend/requirements.in
 pyyaml==6.0.2
     # via drf-spectacular

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,37 +6,61 @@ services:
       POSTGRES_DB: ${POSTGRES_DB}
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-    volumes: [postgres_data:/var/lib/postgresql/data]
-    networks: [blog]
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - blog
 
   backend:
-    build: {context: ../backend, dockerfile: Dockerfile.dev}
+    build:
+      context: ../backend
+      dockerfile: Dockerfile.dev
     env_file: ../.env
     environment:
       POSTGRES_HOST: db
       POSTGRES_PORT: 5432
-    depends_on: [db]
+      API_URL: ${API_URL}
+    depends_on:
+      - db
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:8000/health/ || exit 1"]
+      test:
+        - CMD
+        - curl
+        - -f
+        - http://localhost:8000/health/
       interval: 10s
       retries: 3
-    networks: [blog]
-    volumes: ["../backend:/app", "../media:/app/media"]
+    volumes:
+      - ../backend:/app
+      - ../media:/app/media
+    networks:
+      - blog
+    ports:
+      - "8000:8000"
 
   frontend:
     build:
       context: ../frontend
       dockerfile: Dockerfile.dev
-      args: {API_URL: ${API_URL}}
+      args:
+        API_URL: ${API_URL}
     env_file: ../.env
     environment:
       NEXT_PUBLIC_API_BASE: ${API_URL}
     depends_on:
       backend:
         condition: service_healthy
-    networks: [blog]
-    volumes: ["../frontend:/app", "/app/node_modules", "/app/.next"]
-    ports: ["3000:3000"]
+    volumes:
+      - ../frontend:/app
+      - /app/node_modules
+      - /app/.next
+    networks:
+      - blog
+    ports:
+      - "3000:3000"
 
-volumes: {postgres_data: {}}
-networks: {blog: {driver: bridge}}
+volumes:
+  postgres_data: {}
+
+networks:
+  blog: {}

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1,0 +1,29 @@
+# Быстрый старт для разработчиков
+
+## Переменные окружения
+Создайте файл `.env` на основе `.env.example` в корне проекта. Основные настройки:
+
+- `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD` — параметры подключения к PostgreSQL
+- `DJANGO_SECRET_KEY` — секретный ключ Django
+- `DJANGO_DEBUG` — включить режим отладки (`True` или `False`)
+- `API_URL` — базовый URL API, используется фронтендом
+- `DJANGO_ALLOWED_HOSTS` — допустимые хосты для Django
+- `CORS_ALLOWED_ORIGINS` — разрешённые источники CORS
+
+## Запуск проекта
+1. Установите зависимости:
+   ```bash
+   pip install -r backend/requirements.txt
+   npm ci --prefix frontend
+   ```
+2. Скопируйте `.env.example` в `.env` и при необходимости отредактируйте параметры.
+3. Запустите сервисы:
+   ```bash
+   docker compose up --build
+   ```
+   Backend будет доступен на <http://localhost:8000>, frontend — на <http://localhost:3000>.
+
+## Тесты
+- **Backend:** `pytest -q backend`
+- **Frontend:** `npm test --prefix frontend`
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ exclude = '''
 '''
 
 [tool.isort]
-profile = "black"
+profile = "django"
 line_length = 88
 multi_line_output = 3
 include_trailing_comma = true


### PR DESCRIPTION
## Изменения
- переход на `django-environ` для чтения настроек
- переработан `docker-compose.yml` – блоковый синтаксис, переменная `API_URL`
- CI использует `isort --profile=django` и `npm install --legacy-peer-deps`
- добавлен документ `docs/ONBOARDING.md`
- актуализированы `.env.example` и README

## Тесты
- `pytest -q backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_6854345fba1083298a17e6839ed26425